### PR TITLE
Remove contributions stat

### DIFF
--- a/components/CollectiveModal.tsx
+++ b/components/CollectiveModal.tsx
@@ -49,7 +49,7 @@ export default function CollectiveModal({ isOpen, onClose, collective, locale = 
     return null;
   }
 
-  const statsLabelClasses = 'flex items-center text-xs font-bold uppercase text-gray-700';
+  const statsLabelClasses = 'flex items-center text-xs font-bold uppercase text-gray-700 leading-6';
   return (
     <React.Fragment>
       <Transition appear show={isOpen} as={Fragment}>
@@ -140,7 +140,7 @@ export default function CollectiveModal({ isOpen, onClose, collective, locale = 
                         })}
                       </div>
                       <div className={statsLabelClasses}>Contributors</div>{' '}
-                      <div>{collective.stats?.ALL.contributors.toLocaleString(locale)}</div>
+                      <div>{(collective.stats?.ALL.contributors ?? 0).toLocaleString(locale)}</div>
                       <div className={statsLabelClasses}>Disbursed</div>
                       <div>
                         {formatCurrency(Math.abs(collective.stats?.ALL.spent ?? 0), currency, {

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -5,7 +5,7 @@ import { formatCurrency } from '@opencollective/frontend-components/lib/currency
 const Metric = ({ value, label }: { label: string; value: string }) => {
   return (
     <div className="text-center">
-      <p className="mb-0.5 text-lg font-bold lg:text-3xl lg:font-medium">{value}</p>
+      <p className="mb-0.5 text-lg font-semibold lg:text-3xl">{value}</p>
       <span className="text-sm text-gray-700 lg:text-lg">{label}</span>
     </div>
   );

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -4,17 +4,17 @@ import { formatCurrency } from '@opencollective/frontend-components/lib/currency
 
 const Metric = ({ value, label }: { label: string; value: string }) => {
   return (
-    <div className="p-2 text-center">
-      <p className="mb-0.5 text-xl font-bold lg:text-3xl lg:font-medium">{value}</p>
+    <div className="text-center">
+      <p className="mb-0.5 text-lg font-bold lg:text-3xl lg:font-medium">{value}</p>
       <span className="text-sm text-gray-700 lg:text-lg">{label}</span>
     </div>
   );
 };
 
 export default function Stats({ currency, locale, stats }) {
-  const { raised, totalContributions, totalContributors, collectivesCount } = stats;
+  const { raised, totalContributors, collectivesCount } = stats;
   return (
-    <div className="-mb-2 grid grid-cols-1 divide-y px-4 lg:grid-cols-4 lg:divide-y-0 lg:divide-x lg:px-8">
+    <div className="-mb-2 grid grid-cols-3 gap-1 px-1 lg:divide-x lg:divide-y-0 lg:px-8">
       <Metric value={collectivesCount?.toLocaleString(locale)} label="Collectives" />
       <Metric
         value={formatCurrency(raised, currency, {
@@ -23,7 +23,6 @@ export default function Stats({ currency, locale, stats }) {
         })}
         label="Total raised"
       />
-      <Metric value={totalContributions.toLocaleString(locale)} label="Contributions" />
       <Metric value={totalContributors.toLocaleString(locale)} label="Contributors" />
     </div>
   );

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -30,12 +30,9 @@ export const accountsQuery = gql`
 
         ALL: stats {
           contributorsCount(includeChildren: true)
-          contributionsCount(includeChildren: true)
-
           totalAmountSpent(net: false, includeChildren: true, currency: $currency) {
             valueInCents
           }
-
           totalAmountReceivedTimeSeries(net: true, timeUnit: YEAR, includeChildren: true, currency: $currency) {
             timeUnit
             nodes {
@@ -49,8 +46,6 @@ export const accountsQuery = gql`
 
         PAST_YEAR: stats {
           contributorsCount(includeChildren: true, dateFrom: $yearAgo)
-          contributionsCount(includeChildren: true, dateFrom: $yearAgo)
-
           totalAmountSpent(net: false, includeChildren: true, dateFrom: $yearAgo, currency: $currency) {
             valueInCents
           }
@@ -73,12 +68,9 @@ export const accountsQuery = gql`
 
         PAST_QUARTER: stats {
           contributorsCount(includeChildren: true, dateFrom: $quarterAgo)
-          contributionsCount(includeChildren: true, dateFrom: $quarterAgo)
-
           totalAmountSpent(net: false, includeChildren: true, dateFrom: $quarterAgo, currency: $currency) {
             valueInCents
           }
-
           totalAmountReceivedTimeSeries(
             net: true
             dateFrom: $quarterAgo

--- a/utils/stats.ts
+++ b/utils/stats.ts
@@ -11,7 +11,6 @@ const getCollectiveStats = stats => {
 
   return {
     contributors: stats.contributorsCount,
-    contributions: stats.contributionsCount,
     spent,
     raised,
     raisedSeries,
@@ -36,14 +35,12 @@ export function getTotalStats(collectives, timePeriod) {
       return {
         collectivesCount: collectives.length,
         raised: acc.raised + collective.stats[timePeriod].raised,
-        totalContributions: acc.totalContributions + collective.stats[timePeriod].contributions,
         totalContributors: acc.totalContributors + collective.stats[timePeriod].contributors,
       };
     },
     {
       collectivesCount: 0,
       raised: 0,
-      totalContributions: 0,
       totalContributors: 0,
     },
   );


### PR DESCRIPTION
Based on a discussion in Slack it seems safe to remove # contributions, to focus more on contributors.

This also enables putting all stats on the same row on mobile, saving up lots of vertical space:

Before:
<img width="396" alt="Skärmavbild 2022-12-22 kl  12 05 22" src="https://user-images.githubusercontent.com/1552194/209121092-1e8b5ae3-dd11-4cf3-b0cb-ad862b48d1ad.png">

After:
<img width="397" alt="Skärmavbild 2022-12-22 kl  12 05 32" src="https://user-images.githubusercontent.com/1552194/209121084-d148e8f6-9bbb-4c98-ac9c-b14c5e6174ef.png">

