### PR TITLE
Add end dates for Past time periods

### DIFF
--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -3,8 +3,10 @@ import { gql } from '@apollo/client';
 export const accountsQuery = gql`
   query SearchAccounts(
     $host: [AccountReferenceInput]
-    $quarterAgo: DateTime
-    $yearAgo: DateTime
+    $quarterFrom: DateTime
+    $quarterTo: DateTime
+    $yearFrom: DateTime
+    $yearTo: DateTime
     $currency: Currency
     $limit: Int
     $offset: Int
@@ -45,13 +47,20 @@ export const accountsQuery = gql`
         }
 
         PAST_YEAR: stats {
-          contributorsCount(includeChildren: true, dateFrom: $yearAgo)
-          totalAmountSpent(net: true, includeChildren: true, dateFrom: $yearAgo, currency: $currency) {
+          contributorsCount(includeChildren: true, dateFrom: $yearFrom, dateTo: $yearTo)
+          totalAmountSpent(
+            net: true
+            includeChildren: true
+            dateFrom: $yearFrom
+            dateTo: $yearTo
+            currency: $currency
+          ) {
             valueInCents
           }
           totalAmountReceivedTimeSeries(
             net: true
-            dateFrom: $yearAgo
+            dateFrom: $yearFrom
+            dateTo: $yearTo
             timeUnit: MONTH
             includeChildren: true
             currency: $currency
@@ -67,13 +76,20 @@ export const accountsQuery = gql`
         }
 
         PAST_QUARTER: stats {
-          contributorsCount(includeChildren: true, dateFrom: $quarterAgo)
-          totalAmountSpent(net: true, includeChildren: true, dateFrom: $quarterAgo, currency: $currency) {
+          contributorsCount(includeChildren: true, dateFrom: $quarterFrom, dateTo: $quarterTo)
+          totalAmountSpent(
+            net: true
+            includeChildren: true
+            dateFrom: $quarterFrom
+            dateTo: $quarterTo
+            currency: $currency
+          ) {
             valueInCents
           }
           totalAmountReceivedTimeSeries(
             net: true
-            dateFrom: $quarterAgo
+            dateFrom: $quarterFrom
+            dateTo: $quarterTo
             timeUnit: WEEK
             includeChildren: true
             currency: $currency

--- a/scripts/fetch-data.ts
+++ b/scripts/fetch-data.ts
@@ -79,14 +79,18 @@ async function graphqlRequest(query, variables: any = {}) {
 
 async function fetchDataForPage(host) {
   const { slug, currency, root } = host;
-  const quarterAgo = dayjs.utc().subtract(12, 'week').startOf('isoWeek').toISOString();
-  const yearAgo = dayjs.utc().subtract(12, 'month').startOf('month').toISOString();
+  const quarterFrom = dayjs.utc().subtract(12, 'week').startOf('isoWeek').toISOString();
+  const quarterTo = dayjs.utc().subtract(1, 'week').endOf('isoWeek').toISOString();
+  const yearFrom = dayjs.utc().subtract(12, 'month').startOf('month').toISOString();
+  const yearTo = dayjs.utc().subtract(1, 'month').endOf('month').toISOString();
 
   const variables = {
     ...(root ? { host: host.hostSlugs.map(slug => ({ slug })) } : { host: { slug } }),
     currency,
-    quarterAgo,
-    yearAgo,
+    quarterFrom,
+    quarterTo,
+    yearFrom,
+    yearTo,
     offset: 0,
     limit: 250,
   };


### PR DESCRIPTION
We recently added a fix to not show the current time period in the chart, this PR also makes sure that for the "Past" time periods, (past 12 months, past 12 weeks) we're not including the current period (which would be the 13th month or week) in the data.