### PR TITLE
Include OCF in main query to keep history

### DIFF
--- a/lib/hosts.ts
+++ b/lib/hosts.ts
@@ -46,6 +46,7 @@ export const hosts: {
     root: true,
     name: 'Open Collective',
     hostSlugs: [
+      'foundation',
       'europe',
       'opensource',
       'allforclimate',


### PR DESCRIPTION
Follow up from https://github.com/opencollective/discover/pull/29, to add back OCF to the main query (to keep historical money raised but not include a separate page for OCF)